### PR TITLE
improvement: updated getenv dependency in metro-config to 1.0.0.

### DIFF
--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@expo/config": "3.3.31-alpha.0",
     "chalk": "^4.1.0",
-    "getenv": "^0.7.0",
+    "getenv": "^1.0.0",
     "metro-react-native-babel-transformer": "^0.59.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

Current used version of getenv (0.7.0) in metro-config does not include any type of license. Starting v1.0.0 MIT license is included in the package.

# How

Run `npm install getenv@1.0.0` to update `package.json` file.
